### PR TITLE
Fix 3rd party assets on HTTPS

### DIFF
--- a/includes/init/assets.php
+++ b/includes/init/assets.php
@@ -422,7 +422,7 @@ class WR_Megamenu_Init_Assets {
 		}
 
 		$base_path = WP_PLUGIN_DIR . "/{$plugin_name}";
-		$base_url  = WP_PLUGIN_URL . "/{$plugin_name}";
+		$base_url  = plugin_dir_url("/wr-megamenu/{$plugin_name}");
 
 		// Prepare assets path
 		foreach ( $assets AS $key => $value ) {


### PR DESCRIPTION
On converting a site to HTTPS, I was getting browser warnings because the URLs for 3rd party assets were being generated as HTTP not HTTPS. This change fixed the problem.
