### PR TITLE
Fix multi-languages support (use profile-id)

### DIFF
--- a/includes/helpers/frontend.php
+++ b/includes/helpers/frontend.php
@@ -25,7 +25,7 @@ class WR_Megamenu_Helpers_Frontend {
 			'container_id'    => '',
 			'menu_class'      => 'wr-mega-menu nav-menu',
 			'menu_id'         => 'wr-megamenu-menu-' . $args['menu_type'],
-			'menu'            => $args['menu_type'],
+			'menu'            => $args['profile_id'],
 			'fallback_cb'     => 'wp_page_menu',
 			'before'          => '',
 			'after'           => '',


### PR DESCRIPTION
See : 
- https://wordpress.org/support/topic/malfunction-vr-megamenu-on-multilanguage-site/
- https://wordpress.org/support/topic/mega-menu-not-work-in-other-language/
- https://wordpress.org/support/topic/second-language-menu-doesnt-call-wr-menu/
- https://wordpress.org/support/topic/menu-doesnt-show-in-second-language/

Fix for this all issues.
